### PR TITLE
make spx.dll in search-path optional

### DIFF
--- a/src/TestAdapter/Logger.cs
+++ b/src/TestAdapter/Logger.cs
@@ -1,14 +1,7 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace TestAdapterTest
 {
@@ -101,7 +94,7 @@ namespace TestAdapterTest
             var time = DateTime.Now.ToFileTime().ToString();
             return $"log-test-adatper-{time}-{pid}.log";
         }
- 
+
         private static IMessageLogger logger = null;
 
         private static string _logPath = GetLogPath();

--- a/src/TestAdapter/Properties/AssemblyInfo.cs
+++ b/src/TestAdapter/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/TestAdapter/TestDiscoverer.cs
+++ b/src/TestAdapter/TestDiscoverer.cs
@@ -1,14 +1,9 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace TestAdapterTest
 {

--- a/src/TestAdapter/TestExecutor.cs
+++ b/src/TestAdapter/TestExecutor.cs
@@ -1,15 +1,7 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace TestAdapterTest
 {

--- a/src/TestAdapter/TestRunHost.cs
+++ b/src/TestAdapter/TestRunHost.cs
@@ -11,7 +11,7 @@ namespace TestAdapterTest
 
         public static TestRunHost FromSources(IEnumerable<string> sources) => new TestRunHost(sources);
 
-        public TestRunHost(IEnumerable<string> sources)
+        private TestRunHost(IEnumerable<string> sources)
         {
             if (sources == null) return; // nothing to do
 

--- a/src/TestAdapter/YamlNodeExtensions.cs
+++ b/src/TestAdapter/YamlNodeExtensions.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
 
@@ -72,7 +71,7 @@ namespace TestAdapterTest
                 // ensure each item is either scalar, or sequence of scalar                
                 var invalidItem = (line == null);
                 Logger.LogIf(invalidItem, $"Invalid item at ({item.Start.Line},{item.Start.Column})");
-                if (invalidItem) return null; 
+                if (invalidItem) return null;
 
                 lines.Add(line);
             }
@@ -130,6 +129,6 @@ namespace TestAdapterTest
             tsv = tsv.Replace('\n', '\f');
             Logger.Log($"YamlNodeExtensions.ConvertScalarMapToTsvString: tsv='{tsv}'");
             return tsv;
-        }  
+        }
     }
 }

--- a/src/TestAdapter/YamlTestAdapter.cs
+++ b/src/TestAdapter/YamlTestAdapter.cs
@@ -1,15 +1,10 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace TestAdapterTest
 {
@@ -32,10 +27,10 @@ namespace TestAdapterTest
 
         public static IEnumerable<TestCase> GetTestsFromFile(string source)
         {
-           Logger.Log($"YamlTestAdapter.GetTestsFromFile('{source}')");
+            Logger.Log($"YamlTestAdapter.GetTestsFromFile('{source}')");
 
-           var file = new FileInfo(source);
-           Logger.Log($"YamlTestAdapter.GetTestsFromFile('{source}'): Extension={file.Extension}");
+            var file = new FileInfo(source);
+            Logger.Log($"YamlTestAdapter.GetTestsFromFile('{source}'): Extension={file.Extension}");
 
             return file.Extension.Trim('.') == FileExtensionYaml.Trim('.')
                 ? GetTestsFromYaml(source, file)
@@ -81,7 +76,7 @@ namespace TestAdapterTest
                     yield return test;
                 }
             }
-           Logger.Log($"YamlTestAdapter.GetTestsFromDirectory('{source}', '{directory.FullName}'): EXIT");
+            Logger.Log($"YamlTestAdapter.GetTestsFromDirectory('{source}', '{directory.FullName}'): EXIT");
         }
 
         private static IEnumerable<FileInfo> FindFiles(DirectoryInfo directory)
@@ -97,7 +92,7 @@ namespace TestAdapterTest
             {
                 yield return test;
             }
-           Logger.Log($"YamlTestAdapter.GetTestsFromYaml('{source}', '{file.FullName}'): EXIT");
+            Logger.Log($"YamlTestAdapter.GetTestsFromYaml('{source}', '{file.FullName}'): EXIT");
         }
 
         private static bool IsTrait(Trait trait, string check)
@@ -110,7 +105,7 @@ namespace TestAdapterTest
             Logger.Log($"YamlTestAdapter.FilterTestCases()");
 
             tests = YamlTestCaseFilter.FilterTestCases(tests, runContext, frameworkHandle);
-            
+
             var before = tests.Where(test => test.Traits.Count(x => IsTrait(x, "before")) > 0);
             var after = tests.Where(test => test.Traits.Count(x => IsTrait(x, "after")) > 0);
             var middle = tests.Where(test => !before.Contains(test) && !after.Contains(test));

--- a/src/TestAdapter/YamlTestCaseFilter.cs
+++ b/src/TestAdapter/YamlTestCaseFilter.cs
@@ -1,14 +1,7 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace TestAdapterTest
 {

--- a/src/TestAdapter/YamlTestCaseParser.cs
+++ b/src/TestAdapter/YamlTestCaseParser.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using YamlDotNet.Helpers;
 using YamlDotNet.RepresentationModel;
 
 namespace TestAdapterTest

--- a/src/TestAdapter/YamlTestProperties.cs
+++ b/src/TestAdapter/YamlTestProperties.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using YamlDotNet.RepresentationModel;
 
 namespace TestAdapterTest
 {

--- a/src/TestAdapter/YamlTestRunnerTriggerAttribute.cs
+++ b/src/TestAdapter/YamlTestRunnerTriggerAttribute.cs
@@ -1,14 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System;
 
 namespace TestAdapterTest
 {


### PR DESCRIPTION
when you have single file executable - the `spx.dll` is not necessarily going to be present. make this a warning and if present add the path to the dll in the path like we used to.

otherwise, general namespace cleanup