### PR TITLE
Gimahajan/parallelize tests

### DIFF
--- a/src/TestAdapter/Logger.cs
+++ b/src/TestAdapter/Logger.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace TestAdapterTest
@@ -27,17 +28,32 @@ namespace TestAdapterTest
 
         public static void LogInfo(string text)
         {
-            File.AppendAllText(_logPath, $"{DateTime.Now}: INFO: {text}\n");
+            using (var mutex = new Mutex(false, "Logger Mutex"))
+            {
+                mutex.WaitOne();
+                File.AppendAllText(_logPath, $"{DateTime.Now}: INFO: {text}\n");
+                mutex.ReleaseMutex();
+            }
         }
 
         public static void LogWarning(string text)
         {
-            File.AppendAllText(_logPath, $"{DateTime.Now}: WARNING: {text}\n");
+            using (var mutex = new Mutex(false, "Logger Mutex"))
+            {
+                mutex.WaitOne();
+                File.AppendAllText(_logPath, $"{DateTime.Now}: WARNING: {text}\n");
+                mutex.ReleaseMutex();
+            }
         }
 
         public static void LogError(string text)
         {
-            File.AppendAllText(_logPath, $"{DateTime.Now}: ERROR: {text}\n");
+            using (var mutex = new Mutex(false, "Logger Mutex"))
+            {
+                mutex.WaitOne();
+                File.AppendAllText(_logPath, $"{DateTime.Now}: ERROR: {text}\n");
+                mutex.ReleaseMutex();
+            }
         }
 
         #endregion

--- a/src/TestAdapter/YamlTestAdapter.cs
+++ b/src/TestAdapter/YamlTestAdapter.cs
@@ -43,6 +43,7 @@ namespace TestAdapterTest
         public static void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
             var parallelWorkers = Environment.ProcessorCount;
+            Logger.Log($"YamlTestAdapter.RunTests(): {parallelWorkers} parallel Workers");
             // Must run before, middle, and after testSets in certain order so cannot parallelize those
             // Can parallelize tests within each testSet
             foreach (var testSet in FilterTestCases(tests, runContext, frameworkHandle))

--- a/src/TestAdapter/YamlTestAdapter.cs
+++ b/src/TestAdapter/YamlTestAdapter.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;

--- a/src/TestAdapter/YamlTestProperties.cs
+++ b/src/TestAdapter/YamlTestProperties.cs
@@ -32,6 +32,7 @@ namespace TestAdapterTest
             { "cli", RegisterTestCaseProperty("CLI") },
             { "command", RegisterTestCaseProperty("Command") },
             { "script", RegisterTestCaseProperty("Script") },
+            { "parallelize", RegisterTestCaseProperty("Parallelize") },
             { "foreach", RegisterTestCaseProperty("ForEach") },
             { "arguments", RegisterTestCaseProperty("Arguments") },
             { "expect", RegisterTestCaseProperty("Expect") },


### PR DESCRIPTION
- add ability to parallelize tests by adding a `parallelize` tag to any class, area, or test section in yaml
- Log number of parallel workers
- Add mutex to logger due to parallel execution of tests